### PR TITLE
Resolve warning

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,7 +1,7 @@
 import WPApi from 'wpapi'
 
 <% if (options.extensions) { %>
-import { registerWuxt } from 'wpapi-extensions'
+import * as WPApiExtensions from 'wpapi-extensions'
 <% } %>
 
 const options = <%= serialize(options) %>
@@ -14,7 +14,7 @@ export default async (ctx, inject) => {
   <% } %>
 
   <% if (options.extensions) { %>
-    registerWuxt(wp)
+    WPApiExtensions.registerWuxt(wp)
   <% } %>
 
   <% if (options.customRoutes) { %>


### PR DESCRIPTION
 WARN  in ./.nuxt/wp.js                                                                                                                 friendly-errors 19:57:43

"export 'registerWuxt' was not found in 'wpapi-extensions' 

This is same in context but for webpack is different scenario and no warning is return.