### PR TITLE
Required dynamically

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,20 +1,17 @@
 import WPApi from 'wpapi'
 
-<% if (options.extensions) { %>
-import * as WPApiExtensions from 'wpapi-extensions'
-<% } %>
-
 const options = <%= serialize(options) %>
 let wp = new WPApi(options)
-
 
 export default async (ctx, inject) => {
   <% if (options.discover) { %>
     wp = await WPApi.discover(options.endpoint);
   <% } %>
-
+    
   <% if (options.extensions) { %>
-    WPApiExtensions.registerWuxt(wp)
+    require(['wpapi-extensions'], function(WPApiExtensions) {
+      WPApiExtensions.registerWuxt(wp)
+    });
   <% } %>
 
   <% if (options.customRoutes) { %>


### PR DESCRIPTION
Importing wpapi-extensions before export was bad idea - it work but it didn't fix problem
Extension is exported by "Parcel" that don't cooperate with webpack bundler, browser and node in the same time.
I try in 'wpapi-extensions' Parcel 1.0, Parcel 2.0 alpha, custom configuration with node setup and witchout.
One try is getting resolved as node/browser and webpack cannot import (info in browser).
Second try It fail in browser as "nodefine" or "parcel not recognised" and "export undefined".
This require is the only way to get fully rid any import problem and work browser/webpack/generate bundle.
Pleas, test It before apply as I can have different scenario