### PR TITLE
Support auth option

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -9,7 +9,16 @@ let wp = new WPApi(options)
 
 
 export default async (ctx, inject) => {
-  <% if (options.discover) { %>
+  <% if (options.discover && options.auth) { %>
+    wp = await WPApi.discover(options.endpoint).then(function( site ) {
+      return site.auth({
+          username: options.username,
+          password: options.password
+      });
+  });
+  <% } %>
+
+  <% if (options.discover && !options.auth) { %>
     wp = await WPApi.discover(options.endpoint);
   <% } %>
 


### PR DESCRIPTION
As describe in https://github.com/WP-API/node-wpapi#authenticating-with-auto-discovery
Just use it like example:
```js
    {
      src: 'wp-nuxt',
      options: {
        discover: true,
        endpoint: `${process.env.API_URL}${process.env.API_AFFIX}`,
        extensions: true,
        username: `${process.env.WP_USER}`,
        password: `${process.env.WP_PASSWORD}`,
        auth: true,
      },
```
Pull request simply add missing option if auth is true and use provided credentials to get new paths
New path introduced with different permission scheme: https://core.trac.wordpress.org/ticket/40878#comment:72

Right now error is show without solution:
```js
 ERROR  Sorry, you are not allowed to view menu locations.
```